### PR TITLE
give default value to $singleSelection to fix Typed property must not…

### DIFF
--- a/src/fields/CategoryGroupsField.php
+++ b/src/fields/CategoryGroupsField.php
@@ -30,7 +30,7 @@ class CategoryGroupsField extends Field implements PreviewableFieldInterface
     /**
      * @var bool|null Whether this field is limited to selecting one category group
      */
-    public ?bool $singleSelection;
+    public ?bool $singleSelection = false;
 
     /**
      * @inheritdoc


### PR DESCRIPTION
Not sure if it's because I'm on php 8 or not on a Craft 4 project, but giving $singleSelection a default value fixes an error I have when using this field in the admin. 

`Typed property must not be accessed before initialization`